### PR TITLE
Add Vercel analytics to root layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import './clerk.css'
 import './prism.css'
 
 import { ClerkProvider } from '@clerk/nextjs'
+import { Analytics } from '@vercel/analytics/react'
 import type { Metadata, Viewport } from 'next'
 
 import { ThemeProvider } from '~/app/(main)/ThemeProvider'
@@ -86,6 +87,7 @@ export default function RootLayout({
           >
             {children}
           </ThemeProvider>
+          <Analytics />
         </body>
       </html>
     </ClerkProvider>


### PR DESCRIPTION
## Summary
- import the Vercel Analytics component in the root layout
- render the analytics tracker alongside the existing theme provider

## Testing
- `pnpm lint` *(fails: invalid environment variables required for Next.js configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6d7420ec83238882fdc465c963cd