### PR TITLE
Enhance activity feed with multi-state support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,24 @@ pnpm build
 ```
 
 通过 [Vercel](https://vercel.com/) 一键部署。
+
+### Activity 状态同步
+
+站点的 Activity 组件会从 Upstash Redis 读取以下键值：
+
+| 键名 | 类型 | 说明 |
+| --- | --- | --- |
+| `activity:app` | `string` | 当前前台应用的标识，用于选择 `/public/apps/` 下对应的图标 |
+| `activity:track` | `object \| null` | 当前播放的音轨信息，字段包含 `title`、可选的 `artist`、`app`、`artwork` |
+| `activity:updatedAt` | `string` | ISO 8601 时间戳，记录最近一次同步时间 |
+
+可以通过脚本 `pnpm activity:update` 快速写入这些键，脚本会读取如下环境变量：
+
+- `ACTIVITY_APP`
+- `ACTIVITY_TRACK_TITLE`
+- `ACTIVITY_TRACK_ARTIST`
+- `ACTIVITY_TRACK_APP`
+- `ACTIVITY_TRACK_ARTWORK`
+- `ACTIVITY_CLEAR_TRACK`（可选，设置为 `true` 可清空曲目状态）
+
+脚本会自动更新时间戳 `activity:updatedAt`，并在缺省 `ACTIVITY_TRACK_APP` 时回落到 `ACTIVITY_APP` 或 `now-playing`。请确保新添加的应用或状态在 `public/apps/` 中有同尺寸的 PNG 图标。

--- a/app/(main)/Activity.tsx
+++ b/app/(main)/Activity.tsx
@@ -6,48 +6,89 @@ import React from 'react'
 import { useQuery } from 'react-query'
 
 import { Tooltip } from '~/components/ui/Tooltip'
+import type { ActivityResponse, ActivityTrack } from '~/types/activity'
 
-const appLabels: { [app: string]: string } = {
-  slack: 'Slack',
-  arc: 'Arc',
-  craft: 'Craft',
-  tower: 'Tower',
-  vscode: 'VS Code',
-  webstorm: 'WebStorm',
-  linear: 'Linear',
-  figma: 'Figma',
-  telegram: 'Telegram',
-  wechat: '微信',
-  discord: 'Discord',
-  cron: 'Cron',
-  mail: '邮件',
-  safari: 'Safari',
-  music: 'Apple Music',
-  finder: '访达',
-  messages: '信息',
-  live: 'Ableton Live',
-  screenflow: 'ScreenFlow',
-  resolve: 'DaVinci Resolve',
+type AppMetadata = {
+  label: string
+  icon?: string
 }
+
+const DEFAULT_ACTIVITY_HOSTS = ['cali.so', 'www.cali.so', 'localhost', '127.0.0.1']
+const configuredHosts = (process.env.NEXT_PUBLIC_ACTIVITY_HOSTS ?? '')
+  .split(',')
+  .map((host) => host.trim())
+  .filter(Boolean)
+const ACTIVITY_ALLOWED_HOSTS =
+  configuredHosts.length > 0 ? configuredHosts : DEFAULT_ACTIVITY_HOSTS
+
+const appLabels: Record<string, AppMetadata> = {
+  slack: { label: 'Slack' },
+  arc: { label: 'Arc' },
+  craft: { label: 'Craft' },
+  tower: { label: 'Tower' },
+  vscode: { label: 'VS Code' },
+  webstorm: { label: 'WebStorm' },
+  linear: { label: 'Linear' },
+  figma: { label: 'Figma' },
+  telegram: { label: 'Telegram' },
+  wechat: { label: '微信' },
+  discord: { label: 'Discord' },
+  cron: { label: 'Cron' },
+  mail: { label: '邮件' },
+  safari: { label: 'Safari' },
+  music: { label: 'Apple Music' },
+  finder: { label: '访达' },
+  messages: { label: '信息' },
+  live: { label: 'Ableton Live' },
+  screenflow: { label: 'ScreenFlow' },
+  resolve: { label: 'DaVinci Resolve' },
+  warp: { label: 'Warp' },
+  'now-playing': { label: '正在播放', icon: 'music' },
+}
+
 export function Activity() {
-  const { data } = useQuery<{ app: string }>(
+  const { data } = useQuery<ActivityResponse>(
     'activity',
-    () => fetch('/api/activity').then((res) => res.json()),
+    async () => {
+      const res = await fetch('/api/activity', {
+        cache: 'no-store',
+      })
+      if (!res.ok) {
+        throw new Error('Failed to load activity')
+      }
+
+      const payload = (await res.json()) as Partial<ActivityResponse>
+
+      const sanitizedTrack = normalizeTrack(payload.track)
+
+      return {
+        app: payload.app ?? null,
+        track: sanitizedTrack,
+        updatedAt: payload.updatedAt ?? null,
+      }
+    },
     {
       refetchInterval: 5000,
       enabled:
-        typeof window === 'undefined'
-          ? false
-          : new URL(window.location.href).hostname === 'cali.so',
+        typeof window !== 'undefined' &&
+        ACTIVITY_ALLOWED_HOSTS.includes(window.location.hostname),
     }
   )
   const [open, setOpen] = React.useState(false)
 
-  if (!data) {
+  if (!data || (!data.app && !data.track)) {
     return null
   }
 
-  const { app } = data
+  const { app, track, updatedAt } = data
+  const iconApp = track ? track.app ?? 'now-playing' : app
+  const iconName = getAppIcon(iconApp)
+  const trackSubtitle = track
+    ? [track.artist, getAppLabel(track.app ?? null) ?? getAppLabel(app)]
+        .filter(Boolean)
+        .join(' · ')
+    : null
+  const updatedRelative = formatRelativeTime(updatedAt)
 
   return (
     <Tooltip.Provider disableHoverableContent>
@@ -65,8 +106,8 @@ export function Activity() {
             <Image
               width={32}
               height={32}
-              src={`/apps/${app}.png`}
-              alt={app}
+              src={`/apps/${iconName}.png`}
+              alt={getAppLabel(iconApp) ?? iconName ?? 'activity'}
               priority
               fetchPriority="high"
               unoptimized
@@ -79,12 +120,53 @@ export function Activity() {
             <Tooltip.Portal forceMount>
               <Tooltip.Content asChild>
                 <motion.div
-                    className="mt-1"
+                  className="mt-1 max-w-[260px] rounded-lg border border-zinc-200/50 bg-white/90 px-3 py-2 text-sm text-zinc-900 shadow-lg backdrop-blur-md dark:border-zinc-700/60 dark:bg-zinc-900/85 dark:text-zinc-100"
                   initial={{ opacity: 0, scale: 0.96 }}
                   animate={{ opacity: 1, scale: 1 }}
                   exit={{ opacity: 0, scale: 0.95 }}
                 >
-                  Cali 在使用 {appLabels[app] ?? app}
+                  {track ? (
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded-md bg-zinc-100/80 dark:bg-zinc-800/80">
+                        <Image
+                          src={`/apps/${iconName}.png`}
+                          alt={iconName ?? 'activity icon'}
+                          width={40}
+                          height={40}
+                          className="h-10 w-10 select-none object-contain"
+                          unoptimized
+                        />
+                      </div>
+                      <div className="flex min-w-0 flex-col">
+                        <span className="truncate font-medium leading-tight">
+                          {track.title}
+                        </span>
+                        {trackSubtitle && (
+                          <span className="truncate text-xs text-zinc-500 dark:text-zinc-400">
+                            {trackSubtitle}
+                          </span>
+                        )}
+                        {(updatedRelative || getAppLabel(app)) && (
+                          <span className="mt-1 text-[11px] uppercase tracking-[0.12em] text-zinc-400 dark:text-zinc-500">
+                            {[getAppLabel(track.app ?? null) ?? getAppLabel(app), updatedRelative]
+                              .filter(Boolean)
+                              .join(' · ')}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="flex flex-col">
+                      <span className="font-medium leading-tight">
+                        Cali 正在使用 {getAppLabel(app) ?? app}
+                      </span>
+                      {updatedRelative && (
+                        <span className="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
+                          更新于 {updatedRelative}
+                        </span>
+                      )}
+                    </div>
+                  )}
                 </motion.div>
               </Tooltip.Content>
             </Tooltip.Portal>
@@ -93,4 +175,62 @@ export function Activity() {
       </Tooltip.Root>
     </Tooltip.Provider>
   )
+}
+
+function getAppLabel(app: string | null | undefined) {
+  if (!app) return null
+  return appLabels[app]?.label ?? app
+}
+
+function getAppIcon(app: string | null | undefined) {
+  if (!app) {
+    return 'finder'
+  }
+
+  return appLabels[app]?.icon ?? app
+}
+
+function normalizeTrack(track: ActivityTrack | null | undefined): ActivityTrack | null {
+  if (!track || typeof track.title !== 'string' || track.title.length === 0) {
+    return null
+  }
+
+  return {
+    title: track.title,
+    artist: track.artist ?? null,
+    app: track.app ?? null,
+    artwork: track.artwork ?? null,
+  }
+}
+
+function formatRelativeTime(isoTimestamp: string | null | undefined) {
+  if (!isoTimestamp) {
+    return null
+  }
+
+  const date = new Date(isoTimestamp)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+
+  const diffMs = date.getTime() - Date.now()
+  const formatter = new Intl.RelativeTimeFormat('zh-CN', { numeric: 'auto' })
+
+  const diffSeconds = Math.round(diffMs / 1000)
+  if (Math.abs(diffSeconds) < 60) {
+    return formatter.format(diffSeconds, 'second')
+  }
+
+  const diffMinutes = Math.round(diffSeconds / 60)
+  if (Math.abs(diffMinutes) < 60) {
+    return formatter.format(diffMinutes, 'minute')
+  }
+
+  const diffHours = Math.round(diffMinutes / 60)
+  if (Math.abs(diffHours) < 24) {
+    return formatter.format(diffHours, 'hour')
+  }
+
+  const diffDays = Math.round(diffHours / 24)
+  return formatter.format(diffDays, 'day')
 }

--- a/app/(main)/Header.tsx
+++ b/app/(main)/Header.tsx
@@ -17,6 +17,7 @@ import {
 import { usePathname } from 'next/navigation'
 import React from 'react'
 
+import { Activity } from '~/app/(main)/Activity'
 import { NavigationBar } from '~/app/(main)/NavigationBar'
 import { ThemeSwitcher } from '~/app/(main)/ThemeSwitcher'
 import {
@@ -271,31 +272,18 @@ export function Header() {
                 <NavigationBar.Desktop className="pointer-events-auto relative z-50 hidden md:block" />
               </div>
               <motion.div
-                className="flex justify-end gap-3 md:flex-1"
+                className="flex items-center justify-end gap-3 md:flex-1"
                 initial={{ opacity: 0, y: -20, scale: 0.95 }}
                 animate={{ opacity: 1, y: 0, scale: 1 }}
               >
+                <div className="pointer-events-auto hidden sm:block">
+                  <Activity />
+                </div>
                 <UserInfo />
                 <div className="pointer-events-auto">
                   <ThemeSwitcher />
                 </div>
               </motion.div>
-              {/* 
-              <AnimatePresence>
-                {!isHomePage && (
-                  <motion.div
-                    className="absolute left-14 top-1 flex h-8 items-center"
-                    initial={{ opacity: 0, scale: 0.3 }}
-                    animate={{
-                      opacity: 1,
-                      scale: 1,
-                      transition: { delay: 1 },
-                    }}
-                  >
-                    <Activity />
-                  </motion.div>
-                )}
-              </AnimatePresence> */}
             </div>
           </Container>
         </div>

--- a/app/api/activity/route.ts
+++ b/app/api/activity/route.ts
@@ -2,6 +2,7 @@ import { Ratelimit } from '@upstash/ratelimit'
 import { type NextRequest, NextResponse } from 'next/server'
 
 import { redis } from '~/lib/redis'
+import type { ActivityResponse, ActivityTrack } from '~/types/activity'
 
 export const runtime = 'edge'
 
@@ -11,16 +12,62 @@ export async function GET(req: NextRequest) {
     limiter: Ratelimit.slidingWindow(5, '5 s'),
     analytics: true,
   })
-  const { success } = await ratelimit.limit('activity:app' + `_${req.ip ?? ''}`)
+  const ratelimitKey = ['activity:ratelimit', req.ip ?? 'unknown']
+    .filter(Boolean)
+    .join(':')
+  const { success } = await ratelimit.limit(ratelimitKey)
   if (!success) {
     return new Response('Too Many Requests', {
       status: 429,
     })
   }
 
-  const app = await redis.get('activity:app')
+  const [appRaw, trackRaw, updatedAtRaw] = await redis.mget<
+    string | ActivityTrack
+  >('activity:app', 'activity:track', 'activity:updatedAt')
 
-  return NextResponse.json({
-    app,
-  })
+  let track: ActivityTrack | null = null
+
+  if (trackRaw) {
+    if (typeof trackRaw === 'string') {
+      try {
+        const parsed = JSON.parse(trackRaw) as ActivityTrack
+        track = normalizeTrack(parsed)
+      } catch {
+        track = null
+      }
+    } else if (isActivityTrack(trackRaw)) {
+      track = normalizeTrack(trackRaw)
+    }
+  }
+
+  const response: ActivityResponse = {
+    app: typeof appRaw === 'string' ? appRaw : null,
+    track,
+    updatedAt: typeof updatedAtRaw === 'string' ? updatedAtRaw : null,
+  }
+
+  return NextResponse.json(response)
+}
+
+function isActivityTrack(value: unknown): value is ActivityTrack {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const maybeTrack = value as { title?: unknown }
+  return typeof maybeTrack.title === 'string'
+}
+
+function normalizeTrack(track: ActivityTrack): ActivityTrack | null {
+  if (!track || typeof track.title !== 'string' || track.title.length === 0) {
+    return null
+  }
+
+  return {
+    title: track.title,
+    artist: track.artist ?? null,
+    app: track.app ?? null,
+    artwork: track.artwork ?? null,
+  }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev:email": "email dev -p 3333",
     "dev:turbo": "next dev --turbo",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "activity:update": "node scripts/update-activity.mjs"
   },
   "dependencies": {
     "@clerk/nextjs": "^4.29.9",

--- a/scripts/update-activity.mjs
+++ b/scripts/update-activity.mjs
@@ -1,0 +1,57 @@
+import 'dotenv/config'
+
+import { Redis } from '@upstash/redis'
+
+const {
+  UPSTASH_REDIS_REST_URL,
+  UPSTASH_REDIS_REST_TOKEN,
+  ACTIVITY_APP,
+  ACTIVITY_TRACK_TITLE,
+  ACTIVITY_TRACK_ARTIST,
+  ACTIVITY_TRACK_APP,
+  ACTIVITY_TRACK_ARTWORK,
+  ACTIVITY_CLEAR_TRACK,
+} = process.env
+
+if (!UPSTASH_REDIS_REST_URL || !UPSTASH_REDIS_REST_TOKEN) {
+  throw new Error('Missing Upstash Redis credentials. Set UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN.')
+}
+
+const redis = new Redis({
+  url: UPSTASH_REDIS_REST_URL,
+  token: UPSTASH_REDIS_REST_TOKEN,
+})
+
+const now = new Date().toISOString()
+const app = ACTIVITY_APP ?? null
+
+const track = ACTIVITY_TRACK_TITLE
+  ? {
+      title: ACTIVITY_TRACK_TITLE,
+      artist: ACTIVITY_TRACK_ARTIST ?? null,
+      app: ACTIVITY_TRACK_APP ?? app ?? 'now-playing',
+      artwork: ACTIVITY_TRACK_ARTWORK ?? null,
+    }
+  : null
+
+const pipeline = redis.pipeline()
+
+if (app) {
+  pipeline.set('activity:app', app)
+}
+
+if (track) {
+  pipeline.set('activity:track', track)
+} else if (ACTIVITY_CLEAR_TRACK === 'true') {
+  pipeline.del('activity:track')
+}
+
+pipeline.set('activity:updatedAt', now)
+
+await pipeline.exec()
+
+console.log('✅ Activity updated', {
+  app,
+  track,
+  updatedAt: now,
+})

--- a/types/activity.ts
+++ b/types/activity.ts
@@ -1,0 +1,12 @@
+export type ActivityTrack = {
+  title: string
+  artist?: string | null
+  app?: string | null
+  artwork?: string | null
+}
+
+export type ActivityResponse = {
+  app: string | null
+  track: ActivityTrack | null
+  updatedAt: string | null
+}


### PR DESCRIPTION
## Summary
- fetch the Redis-stored activity app, track, and timestamp together, ensuring the Upstash `mget` call uses the proper variadic form and guards the parsed track payload before normalization
- extend the Activity client UI to parse the richer payload, render track details, and surface the widget in the header
- add a reusable script and documentation updates for writing the new activity keys to Upstash

## Testing
- SKIP_ENV_VALIDATION=1 pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cd6651023483239d58c5dabdf11ef9